### PR TITLE
fix: continuous tratteria service rule reconciliation

### DIFF
--- a/service/pkg/generationrules/v1alpha1/rules.go
+++ b/service/pkg/generationrules/v1alpha1/rules.go
@@ -360,7 +360,6 @@ func (gri *GenerationRulesImp) UpdateCompleteRules(generationRules *GenerationRu
 	gri.generationRules = generationRules
 
 	if gri.generationRules.TratteriaConfigGenerationRule != nil {
-
 		if gri.generationRules.TratteriaConfigGenerationRule.SubjectTokens == nil {
 			gri.subjectTokenHandlers = nil
 		} else {

--- a/service/pkg/subjecttokenhandler/subjecttokenhandler.go
+++ b/service/pkg/subjecttokenhandler/subjecttokenhandler.go
@@ -36,7 +36,7 @@ type TokenHandlers struct {
 	selfSignedTokenHandler TokenHandler
 }
 
-func NewTokenHandlers(subjectTokens *SubjectTokens, logger *zap.Logger) *TokenHandlers {
+func NewTokenHandlers(subjectTokens SubjectTokens, logger *zap.Logger) *TokenHandlers {
 	handlers := &TokenHandlers{}
 
 	if subjectTokens.OIDC != nil {


### PR DESCRIPTION
## Issue

Tratteria Service configuration was continuously reconciled despite having the latest configuration. This occurred due to:

1. The generationrule package providing a reference to the access evaluation configuration.
2. The accessevaluation package modifying this configuration when resolving environment-based token values.

## Fix

1. The generationrule package now provides a copy of the access evaluation configuration.
2. The accessevaluation package no longer modifies the received configuration.

These changes prevent unnecessary reconciliation cycles of Tratteria service configuration.